### PR TITLE
Increase check time to 2 hours

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -15,10 +15,10 @@ resources:
       uri: https://github.com/alphagov/govuk-speedcurve-lux-js-monitor.git
       branch: master
 
-  - name: every-30m
+  - name: every-2h
     type: time
     source:
-      interval: 30m
+      interval: 2h
 
   - name: govuk-frontenders-slack
     type: slack-notification
@@ -35,7 +35,7 @@ jobs:
 
   - name: speedcurve-monitor
     plan:
-      - get: every-30m
+      - get: every-2h
         trigger: true
       - task: Speedcurve monitor
         config:


### PR DESCRIPTION
Every 30 minutes ends up with quite a lot of spam in the Slack channel.