### PR TITLE
Temporarily bumped to 24 hours

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -15,10 +15,10 @@ resources:
       uri: https://github.com/alphagov/govuk-speedcurve-lux-js-monitor.git
       branch: master
 
-  - name: every-2h
+  - name: every-24h
     type: time
     source:
-      interval: 2h
+      interval: 24h
 
   - name: govuk-frontenders-slack
     type: slack-notification
@@ -35,7 +35,7 @@ jobs:
 
   - name: speedcurve-monitor
     plan:
-      - get: every-2h
+      - get: every-24h
         trigger: true
       - task: Speedcurve monitor
         config:


### PR DESCRIPTION
Bumping the alert to once every 24 hours while I contact SpeedCurve.