### PR TITLE
Update the concorse logging for the latest version

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -52,7 +52,7 @@ jobs:
             args:
               - -c
               - |
-                curl https://cdn.speedcurve.com/js/lux.js\?id\=47044334 | grep 'version="214"' || exit 1
+                curl https://cdn.speedcurve.com/js/lux.js\?id\=47044334 | grep 't="216"' || exit 1
         on_failure:
           put: govuk-frontenders-slack
           params:


### PR DESCRIPTION
Looks like SC have added uglification, so `version` becomes `t`.